### PR TITLE
Removing margin and padding from body

### DIFF
--- a/index.go
+++ b/index.go
@@ -94,6 +94,7 @@ const indexTmpl string = `
       {{end}}
 
       window.ui = ui
+      document.getElementsByTagName("body")[0].style="margin:0;padding:0" 
     }
     </script>
   </body>


### PR DESCRIPTION
Without the change I've made there is a default margin on the body, or maybe its padding I didn't really check, the point is there is a gap between the outter edges of the browser and the outer edges of the UI.

I've noticed this for years, because this isn't the first time I've used this. Its been bugging me like crazy so I finally cracked and decided to fork just fix this one little thing, and really it takes a single line of js, or theoretically you could do it in CSS too.

With the change there is no longer the gap and people like me who get annoyed by little things like this can sleep easier at night.